### PR TITLE
Add qnote — minimal Tauri notepad for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It helps to organize your files and folders with tags and colors.
 * [Tangent Notes](https://www.tangentnotes.com/) - Open source, local-first, with live markdown, sliding panes, two way links and more. Designed to let you write the way you think.
 * [Perpetual Notes](https://www.enselsoftware.com/product/PerpetualNotes.html) - Save notes in RTF with rich text formatting and images, meeting notes, web pages, projects, travel plan, research drafts.
 * [Goodnotes](https://www.goodnotes.com/) - Write, type, and collaborate — all in one intelligent place
+* [qnote](https://github.com/Omibranch/qnote) - Minimal frameless desktop notepad for Linux with Markdown support, PDF export via Typst, OCR, and automatic version history. Built with Tauri 2. Available on AUR.
  
 #### Knowledge Graph style
 * [Logseq](https://github.com/logseq/logseq) - knowledge management and collaboration. It focuses on privacy, longevity, and user control. Plain text files and we currently support both Markdown and Emacs Org mode (more to be added soon).


### PR DESCRIPTION
**qnote** is a minimal frameless desktop notepad for Linux, built with Tauri 2 and Rust.

Features:
- Markdown editing with live preview
- PDF export via Typst (native PDF, not HTML)
- OCR via Tesseract
- Automatic version history with snapshots
- Frameless window with dark/light themes
- Available on AUR

GitHub: https://github.com/Omibranch/qnote

Fits naturally in the Free > General section alongside other local, open-source note-taking apps.